### PR TITLE
Hooking up about Page Contact Form to Formspree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1292,6 +1292,24 @@
         }
       }
     },
+    "@formspree/core": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@formspree/core/-/core-2.6.2.tgz",
+      "integrity": "sha512-cbaNhWQ4BFZWosh1Oa4pKD3CWAK3sn+nK3D1UQj6hO1O+AUH502OabKo5+ugC/P2+d4YZLadIY3mC11Ig4kEzA==",
+      "requires": {
+        "@types/promise-polyfill": "^6.0.3",
+        "fetch-ponyfill": "^6.1.0",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
+    "@formspree/react": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@formspree/react/-/react-2.2.3.tgz",
+      "integrity": "sha512-paiDNr0lsf3XwNiV8SrYQGXdSN471c9boFLesqxM01VimCgA0MwZbyo46cDxWO7ZML6FsuKUOvdjnRguSHFkow==",
+      "requires": {
+        "@formspree/core": "^2.6.1"
+      }
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -2392,6 +2410,11 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog=="
+    },
+    "@types/promise-polyfill": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.4.tgz",
+      "integrity": "sha512-GSCjjH6mDS8jgpT22rEOkZVqZcYj7i9AHJu4ntpvoohEpa0mLAKP/Kz3POMKqABaFsS4TyNHOeoyWpzycddcoQ=="
     },
     "@types/prop-types": {
       "version": "15.7.4",
@@ -6622,6 +6645,14 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-ponyfill": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-6.1.1.tgz",
+      "integrity": "sha512-rWLgTr5A44/XhvCQPYj0X9Tc+cjUaHofSM4lcwjc9MavD5lkjIhJ+h8JQlavPlTIgDpwhuRozaIykBvX9ItaSA==",
+      "requires": {
+        "node-fetch": "~2.6.0"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -10519,6 +10550,11 @@
         }
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -12339,6 +12375,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
+    "promise-polyfill": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
+      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g=="
     },
     "prompts": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@formspree/react": "^2.2.3",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/components/contactForm/contactForm.js
+++ b/src/components/contactForm/contactForm.js
@@ -1,5 +1,5 @@
 import React from "react";
-import useForm from "./useForm";
+import { useForm, ValidationError } from '@formspree/react'
 import "./contactForm.scss"
 
 /**
@@ -8,18 +8,11 @@ import "./contactForm.scss"
  * @constructor
  */
 export default function ContactForm() {
-	const {formData, handleChange} = useForm({
-		firstName: '',
-		lastName: '',
-		email: '',
-		phone: '',
-		message: '',
-	});
 
-	const handleSubmit = event => {
-		event.preventDefault()
-		window.alert(`Submitting ${JSON.stringify(formData, null, 2)}`)
-	};
+  const [state, handleSubmit] = useForm("mrgrrlkv")
+  if (state.succeeded) {
+    return <p>Thank you for getting in touch!</p>
+  } 
 
 	return (
 		<section id={"contact-form-container"}>
@@ -35,10 +28,16 @@ export default function ContactForm() {
 								<div>
 									<input
 										className="small-input"
+                    id="firstName"
 										name="firstName"
-										value={formData.firstName}
-										onChange={handleChange}
+                    type="firstName"
+                    required
 									/>
+                  <ValidationError 
+                    prefix="FirstName" 
+                    field="firstName"
+                    errors={state.errors}
+                  />
 								</div>
 							</div>
 							<div className="contact-form-field">
@@ -46,10 +45,16 @@ export default function ContactForm() {
 								<div>
 									<input
 										className="small-input"
+                    id="lastName"
 										name="lastName"
-										value={formData.lastName}
-										onChange={handleChange}
+                    type="lastName"
+                    required
 									/>
+                  <ValidationError 
+                    prefix="LastName" 
+                    field="firstName"
+                    errors={state.errors}
+                  />
 								</div>
 							</div>
 						</div>
@@ -58,10 +63,16 @@ export default function ContactForm() {
 							<div>
 								<input
 									className="large-input"
+                  id="email"
 									name="email"
-									value={formData.email}
-									onChange={handleChange}
+                  type="email"
+                  required
 								/>
+                <ValidationError 
+                  prefix="Email" 
+                  field="email"
+                  errors={state.errors}
+                />
 							</div>
 						</div>
 						<div className="contact-form-field">
@@ -69,25 +80,36 @@ export default function ContactForm() {
 							<div>
 								<input
 									className="large-input"
+                  id="phone"
 									name="phone"
-									value={formData.phone}
-									onChange={handleChange}
+                  type="phone"
 								/>
+                <ValidationError 
+                  prefix="Phone" 
+                  field="phone"
+                  errors={state.errors}
+                />
 							</div>
 						</div>
 						<div className="contact-form-field">
-							<label className="contact-form-label">Message</label>
+							<label className="contact-form-label">Message*</label>
 							<div>
                   <textarea
 	                  className="message-input"
+                    id="message"
 	                  name="message"
-	                  value={formData.message}
-	                  onChange={handleChange}
+                    type="message"
+                    required
+                  />
+                  <ValidationError 
+                    prefix="Message" 
+                    field="message"
+                    errors={state.errors}
                   />
 							</div>
 						</div>
 						<div className={"contact-button-container"}>
-							<button className="submit-button" type="submit">
+							<button className="submit-button" type="submit" disabled={state.submitting}>
 								Send
 							</button>
 						</div>

--- a/src/pages/about/about.scss
+++ b/src/pages/about/about.scss
@@ -34,7 +34,7 @@
                 }
             }
 
-            @media screen and(max-width: 815px) {
+            @media screen and (max-width: 815px) {
                 flex-direction: column;
                 align-items: center;
                 .about-mission-image-wrapper {


### PR DESCRIPTION
CHANGES in this pull request:

- Added Formspree/react as dependency- (command:  npm install @formspree/react )
- Switched useForm and ValidationError imports from old form to formspree react at top of contactForm.js
- Made message input compulsory as well- I thought allowing people to submit their name and email without message makes no sense, but let me know thoughts 
- (total required fields for submit: Name, Last Name, Email (as before) plus Message)

The old useForm.js has been left in, the file can be deleted once happy with the PR

NOTES:
We should ask UX about what message they want to display on submit and in what style, I've put a placeholder for now

The form submits to spacelabdev@gmail.com.


