### PR TITLE
Remove news and fas

### DIFF
--- a/src/pages/about/about.js
+++ b/src/pages/about/about.js
@@ -17,7 +17,7 @@ export default function About() {
 			<HeroImage/>
 			<MissionStatement/>
 			<Team/>
-			<Faq/>
+      <Faq/>
 			<ContactForm/>
 			<Footer/>
 		</>

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -18,4 +18,4 @@ export default function Home() {
             <Footer />
         </>
     );
-}
+  };

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -2,8 +2,6 @@ import React from "react";
 import HeroImage from "../../components/heroImage/heroImage";
 import Introduction from "./introductionSection";
 import ExoPlanet101 from "./exoPlanet101Section";
-import FeaturedArticles from "./featuredArticlesSection";
-import Explore from "./exploreSection";
 import Footer from "../../components/footer/footer";
 import "./home.scss";
 
@@ -17,8 +15,6 @@ export default function Home() {
             <HeroImage />
             <Introduction />
             <ExoPlanet101 />
-            <FeaturedArticles />
-            <Explore />
             <Footer />
         </>
     );


### PR DESCRIPTION
Removing featured the featured article and news render and import from the home.js page, without deleting either of the components.


![Screenshot 2021-09-30 at 16 55 31](https://user-images.githubusercontent.com/80263983/135489634-45967ca5-20d5-46b6-a3b6-db5df4b591e8.png)


