### PR TITLE
Move chip to its own component

### DIFF
--- a/src/components/chip/Chip.js
+++ b/src/components/chip/Chip.js
@@ -1,0 +1,64 @@
+import React from "react";
+import "./Chip.scss";
+
+/**
+ * Renders Chip components
+ * Receives tag prop which includes the tag string
+ * @param tag string
+ * @returns {JSX.Element}
+ * @constructor
+ */
+
+export default function chip({ tag }) {
+	const chipColors = {
+		orange: "#F05223",
+		gold: "#F3AA1E",
+		green: "#349F65",
+		purple: "#5041AA",
+		lightPurple: "#8923FF",
+		pink: "#F37D7E",
+	};
+
+	const getTagColor = (tag) => {
+		const { orange, gold, green, purple, lightPurple, pink } = chipColors;
+		let color;
+		switch (tag.toLowerCase()) {
+			case "planets": {
+				color = orange;
+				break;
+			}
+			case "space": {
+				color = gold;
+				break;
+			}
+			case "stars": {
+				color = green;
+				break;
+			}
+			case "asteroids": {
+				color = pink;
+				break;
+			}
+			case "astronaut": {
+				color = purple;
+				break;
+			}
+			default: {
+				color = lightPurple;
+			}
+		}
+		return color;
+	};
+
+	return (
+		<div
+			className="chip"
+			id={`chip-${tag}`}
+			style={{
+				backgroundColor: `${getTagColor(tag)}`,
+			}}
+		>
+			<p>{tag}</p>
+		</div>
+	);
+}

--- a/src/components/chip/Chip.scss
+++ b/src/components/chip/Chip.scss
@@ -1,0 +1,14 @@
+.chip {
+	border-radius: 10rem;
+	border: 2px solid #a0a0a9;
+	margin-right: 1rem;
+	margin-bottom: .5rem;
+	padding: 0rem 1rem 0rem 1rem;
+}
+
+.chip p {
+	color: #ffff;
+	padding: 0;
+	margin: 0;
+	font-size: smaller;
+}

--- a/src/pages/podcast/podcast.scss
+++ b/src/pages/podcast/podcast.scss
@@ -24,20 +24,20 @@
 	text-align: left;
 }
 
-.chip {
-	border-radius: 10rem;
-	border: 2px solid #a0a0a9;
-	margin-right: 1rem;
-	margin-bottom: .5rem;
-	padding: 0rem 1rem 0rem 1rem;
-}
+// .chip {
+// 	border-radius: 10rem;
+// 	border: 2px solid #a0a0a9;
+// 	margin-right: 1rem;
+// 	margin-bottom: .5rem;
+// 	padding: 0rem 1rem 0rem 1rem;
+// }
 
-.chip p {
-	color: #ffff;
-	padding: 0;
-	margin: 0;
-	font-size: smaller;
-}
+// .chip p {
+// 	color: #ffff;
+// 	padding: 0;
+// 	margin: 0;
+// 	font-size: smaller;
+// }
 
 .stream-button {
 	box-sizing: border-box;

--- a/src/pages/podcast/podcastCard.js
+++ b/src/pages/podcast/podcastCard.js
@@ -3,6 +3,7 @@ import applePodcast from "../../assets/podcastAssets/apple-podcasts.svg";
 import spotify from "../../assets/podcastAssets/spotify.svg";
 import youtube from "../../assets/podcastAssets/youtube.svg";
 import "./podcast.scss";
+import Chip from "../../components/chip/Chip";
 
 /**
  * Renders Podcast Cards
@@ -25,47 +26,9 @@ export default function podcastCard({ card }) {
 		spotifyLink,
 	} = card;
 
-	const chipColors = {
-		orange: "#F05223",
-		gold: "#F3AA1E",
-		green: "#349F65",
-		purple: "#5041AA",
-		lightPurple: "#8923FF",
-		pink: "#F37D7E",
-	};
-
-	const getTagColor = (tag) => {
-		const { orange, gold, green, purple, lightPurple, pink } = chipColors;
-		let color;
-		switch (tag.toLowerCase()) {
-			case "planets": {
-				color = orange;
-				break;
-			}
-			case "space": {
-				color = gold;
-				break;
-			}
-			case "stars": {
-				color = green;
-				break;
-			}
-			case "asteroids": {
-				color = pink;
-				break;
-			}
-			case "astronaut": {
-				color = purple;
-				break;
-			}
-			default: {
-				color = lightPurple;
-			}
-		}
-		return color;
-	};
-
-	// const getChips = (tags) => {};
+	const chips = tags.map((tag) => {
+		return <Chip tag={tag} />;
+	});
 
 	return (
 		<div className="podcast-card">
@@ -85,21 +48,7 @@ export default function podcastCard({ card }) {
 				<h2
 					style={{ margin: 0, padding: "0rem 0rem .5rem 0rem" }}
 				>{`${title}: (S${seasonNumber}E${episodeNumber})`}</h2>
-				<div style={{ display: "flex" }}>
-					{tags.map((tag) => {
-						return (
-							<div
-								className="chip"
-								id={`chip-${tag}`}
-								style={{
-									backgroundColor: `${getTagColor(tag)}`,
-								}}
-							>
-								<p>{tag}</p>
-							</div>
-						);
-					})}
-				</div>
+				<div style={{ display: "flex" }}>{chips ? chips : null}</div>
 				<h4>About:</h4>
 				<p className="description">{description}</p>
 				<p style={{ marginTop: "1rem" }}>{duration}</p>


### PR DESCRIPTION
This pr adds a separate chip component for use in the podcast pages, which can also be reusable as a tagging system for other pages in the future. It accepts different chip colors based on tags.

The chip component can be found in: src/components/chip
<img width="1091" alt="Screenshot 2023-03-24 at 11 15 26 AM" src="https://user-images.githubusercontent.com/35410545/227566237-4df84ad5-6124-43ff-be03-c10e9c96fa4d.png">
