### PR TITLE
styles discovery page, styles table headers, adds custom scrollbar

### DIFF
--- a/src/globalStyles.scss
+++ b/src/globalStyles.scss
@@ -128,3 +128,22 @@ button {
 button:hover {
 	background: var(--neon-purple);
 }
+
+/* Scroll Bar */
+::-webkit-scrollbar {
+	width: 6px;
+	height: 6px;
+}
+
+::-webkit-scrollbar-track {
+	background: var(--light-gray);
+}
+
+::-webkit-scrollbar-thumb {
+	background: var(--medium-gray);
+	border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+	background: var(--neon-purple);
+}

--- a/src/pages/discovery/discovery.scss
+++ b/src/pages/discovery/discovery.scss
@@ -19,13 +19,14 @@
 
 	#filtersContainer {
 		width: 80vw;
-		border-style: groove;
+		border: 2px solid var(--medium-gray);
+		border-radius: 4px;
 		text-align: left;
-		padding-bottom: 2rem;
+		padding: 3rem 1rem;
 		vertical-align: middle;
 		height: auto;
 		@media (min-width: 1360px) {
-			width: 35vw;
+			width: 32vw;
 		}
 
 		p {
@@ -49,13 +50,12 @@
 
 		#discovery-filter-buttons-container {
 			display: flex;
-			padding: 0 2rem;
+			padding: 0 2rem 0 1rem;
 			width: 100%;
 			justify-content: space-between;
 			gap: 1rem;
 
 			@media (min-width: 700px) {
-				//flex: 1 1 8rem;
 				width: 60%;
 			}
 
@@ -78,7 +78,7 @@
 
 		.filters {
 			padding: 0 2rem 1rem 2rem;
-			border-bottom: 2px solid #a0a0aa;
+			border-bottom: 1px solid var(--light-gray);
 
 			.title {
 				padding: 0.5rem 0;

--- a/src/pages/discovery/table/dataTable.scss
+++ b/src/pages/discovery/table/dataTable.scss
@@ -15,10 +15,10 @@
 	background-color: var(--background-color);
 
 	& .column-header {
-		flex: 0 0 6rem;
+		flex: 0 0 8rem;
 		padding: 3px;
 		background-color: var(--table-header);
-		border-radius: 2px;
+		border-radius: 4px;
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
@@ -26,6 +26,16 @@
 
 		&:first-of-type {
 			flex: 0 0 3rem;
+			flex-direction: column;
+			justify-content: center;
+			gap: 0;
+
+			& p {
+				font-size: 0.9rem;
+				font-weight: bold;
+				margin: 0px;
+				line-height: 1.3;
+			}
 
 			& img {
 				width: 20px;
@@ -55,6 +65,9 @@
 				color: var(--text);
 				font-weight: bold;
 				vertical-align: bottom;
+				font-size: 0.9rem;
+				margin: 5px;
+				line-height: 1.3;
 
 				&.align-right {
 					text-align: right;
@@ -93,7 +106,7 @@
 	margin: 0;
 
 	& .row-element {
-		flex: 0 0 6rem;
+		flex: 0 0 8rem;
 		color: var(text);
 		padding: 3px;
 		word-break: break-all;

--- a/src/pages/discovery/table/tableComponents/tableHeader.js
+++ b/src/pages/discovery/table/tableComponents/tableHeader.js
@@ -1,9 +1,8 @@
 import React, { useState } from "react";
-import dragIcon from "../../../../assets/componentAssets/drag_icon@0.5x.png"
-import rightTriangleUp from "../../../../assets/componentAssets/right-triangle-up.png"
-import rightTriangleDown from "../../../../assets/componentAssets/right-triangle-down.png"
+import dragIcon from "../../../../assets/componentAssets/drag_icon@0.5x.png";
+import rightTriangleUp from "../../../../assets/componentAssets/right-triangle-up.png";
+import rightTriangleDown from "../../../../assets/componentAssets/right-triangle-down.png";
 import SortIcon from "./sortIcon";
-
 
 /**
  * Returns the column headers, based on the order of the column labels inside the stateful array columnHeaders. The
@@ -22,53 +21,69 @@ import SortIcon from "./sortIcon";
  * @return {JSX.Element}
  * @constructor
  */
-export default function TableHeader(
-	{
-		aggregateDataItems,
-		columnHeaders,
-		setColumnHeaders,
-		exoPlanetData,
-		getColumnAlignmentFrom,
-		sortOrder,
-		setSortColName,
-		sortColName,
-		setSortOrder,
-		isSortIconResetNeeded,
-		setIsSortIconResetNeeded,
-	}) {
-
-	const [draggedColumnHeaderIdx, setDraggedColumnHeaderIdx] = useState(null)
+export default function TableHeader({
+	aggregateDataItems,
+	columnHeaders,
+	setColumnHeaders,
+	exoPlanetData,
+	getColumnAlignmentFrom,
+	sortOrder,
+	setSortColName,
+	sortColName,
+	setSortOrder,
+	isSortIconResetNeeded,
+	setIsSortIconResetNeeded,
+}) {
+	const [draggedColumnHeaderIdx, setDraggedColumnHeaderIdx] = useState(null);
 
 	const handleDragStart = (e) => {
 		// note, the IDs of the column headers represent the index position in the columnHeaders array
-		const currentTarget = e.currentTarget
-		setDraggedColumnHeaderIdx(currentTarget.id)
-		const widthOfDraggedElement = currentTarget.offsetWidth
-		const heightOfDraggedElement = e.target.offsetHeight
-		e.dataTransfer.setDragImage(e.currentTarget, widthOfDraggedElement / 2,  heightOfDraggedElement/ 2)
-	}
+		const currentTarget = e.currentTarget;
+		setDraggedColumnHeaderIdx(currentTarget.id);
+		const widthOfDraggedElement = currentTarget.offsetWidth;
+		const heightOfDraggedElement = e.target.offsetHeight;
+		e.dataTransfer.setDragImage(
+			e.currentTarget,
+			widthOfDraggedElement / 2,
+			heightOfDraggedElement / 2
+		);
+	};
 
 	const handleDrop = (e) => {
-		const dropZoneColumnHeaderIdx = e.currentTarget.id
-		const newColumnHeaders = [...columnHeaders]
-		const draggedColumnHeader = newColumnHeaders.splice(draggedColumnHeaderIdx, 1)[0]
-		newColumnHeaders.splice(dropZoneColumnHeaderIdx, 0, draggedColumnHeader)
-		setColumnHeaders(newColumnHeaders)
-	}
+		const dropZoneColumnHeaderIdx = e.currentTarget.id;
+		const newColumnHeaders = [...columnHeaders];
+		const draggedColumnHeader = newColumnHeaders.splice(
+			draggedColumnHeaderIdx,
+			1
+		)[0];
+		newColumnHeaders.splice(
+			dropZoneColumnHeaderIdx,
+			0,
+			draggedColumnHeader
+		);
+		setColumnHeaders(newColumnHeaders);
+	};
 
 	return (
 		<div id={"column-header-container"}>
 			<div className={"column-header first-column"}>
 				<p>1</p>
 				<img src={rightTriangleUp} alt={"right triangle pointing up"} />
-				<img src={rightTriangleDown} alt={"right triangle pointing down"} />
+				<img
+					src={rightTriangleDown}
+					alt={"right triangle pointing down"}
+				/>
 				<p>{exoPlanetData.length.toLocaleString()}</p>
 			</div>
 			{columnHeaders.map((colName, key) => {
 				// find colLabel associated with colName
-				const colItem = aggregateDataItems.filter(item => item.name === colName)
-				const colLabel = colItem[0].label
-				const columnAlignment = getColumnAlignmentFrom(colItem[0].dataType)
+				const colItem = aggregateDataItems.filter(
+					(item) => item.name === colName
+				);
+				const colLabel = colItem[0].label;
+				const columnAlignment = getColumnAlignmentFrom(
+					colItem[0].dataType
+				);
 				return (
 					<div
 						className={"column-header"}
@@ -94,12 +109,14 @@ export default function TableHeader(
 								setSortOrder={setSortOrder}
 								colName={colName}
 								isSortIconResetNeeded={isSortIconResetNeeded}
-								setIsSortIconResetNeeded={setIsSortIconResetNeeded}
+								setIsSortIconResetNeeded={
+									setIsSortIconResetNeeded
+								}
 							/>
 						</div>
 					</div>
-				)
+				);
 			})}
 		</div>
-	)
+	);
 }


### PR DESCRIPTION
Tried to reduce the space in the table headers as much as possible (the issue is the first header needs to be a column unless we want to use different icons). If we were to make that first header a row, we could make the rest of the headers less tall, and wider. But that also has drawbacks (makes the table wider, more difficult to read).

Let me know your thoughts.

I also added a global custom scrollbar which uses SpaceLab colors (wasn't able to get a screenshot of it), and styled the discovery page a little bit.

![localhost_3000_discovery (2)](https://user-images.githubusercontent.com/115611931/235323348-c6f7bd1f-7e0b-462a-9cd2-7460cfdfa4ba.png)
