### PR TITLE
fixes blog carousel styles

### DIFF
--- a/src/components/carouselComponents/blogCarousel/blogCarousel.scss
+++ b/src/components/carouselComponents/blogCarousel/blogCarousel.scss
@@ -22,7 +22,7 @@
 		z-index: 15;
 
 		li {
-			margin: 0 0.5rem 4.5rem;
+			margin: 0 0.5rem;
 		}
 	}
 }
@@ -35,6 +35,14 @@
 	.blog-carousel-image-wrapper {
 		height: 200px;
 		width: 300px;
+		position: relative;
+
+		img {
+			position: absolute;
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
 	}
 
 	.d-block {


### PR DESCRIPTION
Fixes images so they retain their resolution, but are still fit the entire container. Also fixes title positioning.

![localhost_3000_ (5)](https://user-images.githubusercontent.com/115611931/235324232-a83a239c-b116-4ffd-845f-813be7d2bde1.png)
