### PR TITLE
[Chore] Adds alternative if someone else rebased your branch or rebase via GitHub

### DIFF
--- a/DeveloperOnboarding.md
+++ b/DeveloperOnboarding.md
@@ -179,6 +179,13 @@ In your feature branch
 git rebase origin/main
 ```
 
+Alternatively, if someone else rebased your branch say -- github
+You would want to run
+
+```
+git reset --hard origin/"Your branch"
+```
+
 **At a minimum, you should rebase every time a change or update is pushed to main.**
 
 ## Style Guide


### PR DESCRIPTION
Adds documentation for any circumstance where another user has rebased your branch and you attempt to work on your current branch but notice that it is not the same as what is on GitHub. You'll want to run the following command to make sure it's back at the correct head:

```Git reset --hard origin/"Your Branch"``` 