### PR TITLE
#354 fix project button to remove underline

### DIFF
--- a/src/pages/projects/projects.js
+++ b/src/pages/projects/projects.js
@@ -20,7 +20,7 @@ export default function Projects() {
 			</div>
 			<div className="button-wrap">
 				<a href="https://spacelabdev.github.io/Exoplanetarium-3D/">
-				<button style={{ textDecoration: 'none !important' }}>Explore Exoplanetarium</button>
+				<button className="no-underline">Explore Exoplanetarium</button>
 				</a>
 			</div>
 			<Footer />

--- a/src/pages/projects/projects.js
+++ b/src/pages/projects/projects.js
@@ -20,7 +20,7 @@ export default function Projects() {
 			</div>
 			<div className="button-wrap">
 				<a href="https://spacelabdev.github.io/Exoplanetarium-3D/">
-				<button style={{ textDecoration: 'none' }}>Explore Exoplanetarium</button>
+				<button style={{ textDecoration: 'none !important' }}>Explore Exoplanetarium</button>
 				</a>
 			</div>
 			<Footer />

--- a/src/pages/projects/projects.js
+++ b/src/pages/projects/projects.js
@@ -20,7 +20,7 @@ export default function Projects() {
 			</div>
 			<div className="button-wrap">
 				<a href="https://spacelabdev.github.io/Exoplanetarium-3D/">
-				<button className="no-underline">Explore Exoplanetarium</button>
+				<button>Explore Exoplanetarium</button>
 				</a>
 			</div>
 			<Footer />

--- a/src/pages/projects/projects.js
+++ b/src/pages/projects/projects.js
@@ -20,7 +20,7 @@ export default function Projects() {
 			</div>
 			<div className="button-wrap">
 				<a href="https://spacelabdev.github.io/Exoplanetarium-3D/">
-					<button>Explore Exoplanetarium</button>
+				<button style={{ textDecoration: 'none' }}>Explore Exoplanetarium</button>
 				</a>
 			</div>
 			<Footer />

--- a/src/pages/projects/projects.scss
+++ b/src/pages/projects/projects.scss
@@ -38,4 +38,12 @@
 	display: flex;
 	justify-content: center;
 	width: 100%;
+	a {
+		color: white;
+		text-decoration: none;
+	}
+	a:hover {
+		color: white;
+		text-decoration: none;
+	}
 }


### PR DESCRIPTION
 The !important keyword is used to override any other styles that may be set on the element. In this case, we are overriding the default style of the button, which is to have an underline. So this should solve the issue of removing that underline. 
