### PR TITLE
Hotfix - #355 navbar misaligned

### DIFF
--- a/src/components/navigation/mainNavMenu/navigation.js
+++ b/src/components/navigation/mainNavMenu/navigation.js
@@ -39,8 +39,8 @@ export default function Navigation() {
 						>
 							About
 						</Link>
-						<div className={"nav-dropdown"}>
-							<p className={"dropdown-nav-name"}>Resources</p>
+						<Link to={"#"} className={"nav-dropdown nav-link"}>
+							Resources
 							<div className={"dropdown-content"}>
 								<Link
 									className={"nav-link"}
@@ -71,7 +71,7 @@ export default function Navigation() {
 									Podcast
 								</Link>
 							</div>
-						</div>
+						</Link>
 						<Link
 							className={"nav-link"}
 							to={"/blog"}

--- a/src/components/navigation/mainNavMenu/navigation.scss
+++ b/src/components/navigation/mainNavMenu/navigation.scss
@@ -93,7 +93,8 @@ nav {
 			.nav-dropdown {
 				position: relative;
 				display: inline-block;
-				padding: 0.6rem 1rem;
+				padding: 0.5rem 1rem;
+
 				@media (min-width: 1024px) {
 					margin-right: 1rem;
 				}
@@ -116,6 +117,10 @@ nav {
 
 			.nav-dropdown:hover .dropdown-content {
 				display: block;
+			}
+
+			.nav-dropdown.nav-link {
+				cursor: initial;
 			}
 
 			a {


### PR DESCRIPTION
Hello Spacelab team. I have a proposed solution to the issue: https://github.com/spacelabdev/spacelab-react/issues/355.

I converted the RESOURCES div element .nav-dropdown into a (inactive) Link element. This link will not redirect anywhere(achieved by adding to={"#"} prop), and will have the same styles as other nav-links. I also changed the cursor on this to be "initial" instead "pointer" to indicate that the RESOURCES text should not be clicked, but rather the dropdown elements instead.

Here are some screenshots of it looks now:

![image](https://github.com/spacelabdev/spacelab-react/assets/4129325/b7509f7a-b7a6-4d47-82f7-0f043004bffe)

And with displayed dropdown:

![image](https://github.com/spacelabdev/spacelab-react/assets/4129325/08dde0ee-0b52-44f4-acd6-2ebdf72dda97)
