### PR TITLE
adding a/b test version and adjusting styling to Sign Up landing page

### DIFF
--- a/src/pages/landingPages/signUp/CallToAction/CallToAction.js
+++ b/src/pages/landingPages/signUp/CallToAction/CallToAction.js
@@ -1,5 +1,7 @@
 import "./CallToAction.scss";
 import React, { useState } from "react";
+import ThankYou from "./ThankYou/ThankYou";
+import LetsStayInOrbit from "./LetsStayInOrbit/LetsStayInOrbit";
 import planetImage from "../assets/solen-feyissa-54xmXW7tJzo-unsplash.png";
 import closeX from "../assets/close.png"
 import SignUpForm from "./SignUpForm/SignUpForm";
@@ -7,45 +9,38 @@ import { Link } from 'react-router-dom';
 
 export default function CallToAction() {
   const [success, setSuccess] = useState(false);
+  const [text] = useState("b")
 
   function handleSuccess() {
     setSuccess(true);
   }
-
+    
   return (
     <div className="sign-up-landing-page-section cta-container">
-        {success ? (
-            <div className={`cta-text ${success ? 'success-state' : ''}`}>
-                <div className="bounding-box">
-                    <Link 
-                        to={"/"}
-                        style={{ textDecoration: "none" }}
-                    >
-                        <img
-                            src={closeX}
-                            className="close-png"
-                            alt="close png"
-                        />
-                    </Link>
-                </div>
-                <span className="cta-heading">Thank You!</span>
-                <br />
-                <span className="cta-subheading">
-                    You have now subscribed to our email newsletter. You should receive
-                    <br/>
-                    a confirmation email soon. Ad Astra!🚀
-                </span>
-            </div>
-        ) : (
-            <div className="cta-text">
-                <span className="cta-heading">Let's Stay In Orbit!</span>
-                <span className="cta-subheading">
-                    Subscribe now, and join our community of space enthusiasts.
-                </span>
-            </div>
-        )}
+        <div className={`cta-text ${success ? 'success-state' : ''}`}>
+            {success ? 
+                <>
+                    <div className="bounding-box">
+                        <Link 
+                            to={"/"}
+                            style={{ textDecoration: "none" }}
+                        >
+                            <img
+                                src={closeX}
+                                className="close-png"
+                                alt="close png"
+                            />
+                        </Link>
+                    </div>
 
-        {!success && <SignUpForm onSuccess={handleSuccess}/>}
+                    <ThankYou text={text}/>
+                </>
+            : 
+                <LetsStayInOrbit text={text}/> 
+            }
+
+            {!success && <SignUpForm onSuccess={handleSuccess}/>}
+        </div>
 
         <div className="planet-image-wrapper">
             <img

--- a/src/pages/landingPages/signUp/CallToAction/CallToAction.scss
+++ b/src/pages/landingPages/signUp/CallToAction/CallToAction.scss
@@ -1,5 +1,4 @@
 .cta-container {
-    position: relative;
     height: 1100px;
     background-image: url("../assets/paul-volkmer-R5bkvjGHZig-unsplash.jpg");
     background-size: cover;
@@ -11,47 +10,55 @@
     }
 
     .cta-text {
-        position: relative;
+        position: absolute;
+        width: 100%;
+        height: 700px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
         font-family: 'Poppins';
         font-style: normal;
-        width: 90%;
-        left: 50%;
-        top: 7%;
-        transform: translate(-50%, 50%);
         text-align: center;
         color: #FFFFFF;
-        line-height: 1;
-
-        @media only screen and (max-width: 750px) {
-            top: -10%;
-        }
     }
 
     .cta-heading {
-        display: block;
+        width: max(1420px, 90%);
         font-weight: 600;
-        font-size: 85.0847px;
-        padding-bottom: 4%;
+        font-size: 80px;
+
+        @media only screen and (max-width: 750px) {
+            width: 90%;
+            font-size: 50px;
+            line-height: 1;
+        }
     }
 
     .cta-subheading {
-        display: block;
+        width: min(1420px, 90%);
         font-weight: 400;
-        font-size: 25.53px;
-        padding-bottom: 5%;
+        font-size: 25px;
+        line-height: 45px;
+
+        @media only screen and (max-width: 750px) {
+            width: 90%;
+            font-size: 20px;
+            line-height: 1;
+        }
     }
     
     .planet-image-wrapper {
         z-index: 300;
         position: relative;
-        width: 120%; 
-        left: 50%;
-        top: 7%;
-        transform: translate(-50%, 50%);
+        width: 2000px;
+        top: 35%;
+        left: calc(50% - 2000px/2);
 
         @media only screen and (max-width: 750px) {
-            width: 200%;
-            top: -10%;
+            width: 1000px;
+            top: 40%;
+            left: calc(50% - 1000px/2);
         }
     }
 
@@ -75,20 +82,17 @@
     }
 
     .success-state {
-        height: 298px;
-
         .bounding-box {
             z-index: 400;
-            position: fixed;
-            top: -125px;
-            right: 0;
-            display: flex;
-            flex-direction: row-reverse;
+            position: absolute;
+            top: 100px;
+            right: 5%;
 
             @media only screen and (max-width: 750px) {
-                top: -100px;
+                top: 5%;
+                right: 40px;
             }
-            
+
             .close-png {
                 width: 40px;
 
@@ -104,10 +108,6 @@
                 transform: translateY(-1px);
             }
 
-        }
-
-        @media only screen and (max-width: 750px) {
-            height: 434px;
         }
     }
 

--- a/src/pages/landingPages/signUp/CallToAction/LetsStayInOrbit/LetsStayInOrbit.js
+++ b/src/pages/landingPages/signUp/CallToAction/LetsStayInOrbit/LetsStayInOrbit.js
@@ -1,0 +1,9 @@
+export default function LetsStayInOrbit({text}) {
+    return (
+        <>
+            <span className="cta-heading">Let's Stay In Orbit!</span>
+            <br />
+            <span className="cta-subheading">{text === "a" ? "Subscribe now and join our community of space enthusiasts!" : "Join our community of space enthusiasts by signing up for our newsletter! You'll be among the first to hear about the progress of our latest project, Exoplanetarium, which locates all known exoplanets. You'll get exclusive access to all the latest news and information about Exoplanetarium straight to your inbox."}</span>
+        </>
+     )
+}

--- a/src/pages/landingPages/signUp/CallToAction/SignUpForm/SignUpForm.scss
+++ b/src/pages/landingPages/signUp/CallToAction/SignUpForm/SignUpForm.scss
@@ -1,14 +1,11 @@
 .cta-container {
     .sign-up-button-container {
+        margin-top: 3%;
         z-index: 600;
-        position: relative;
         width: 561.56px;
         height: 71.47px;
-        left: 50%;
-        top: 17%;
-        transform: translate(-50%, 50%);
-        text-align: center;
         overflow: hidden;
+
         border-radius: 30.6305px;
         border-top: .25px solid rgba(255, 255, 255, 1);
         border-right: .25px solid rgba(255, 255, 255, 0.5);
@@ -18,9 +15,8 @@
         background: conic-gradient(#08F969 75deg, #100BF7 90deg, #0BA2F7 100deg, #08F969 110deg, #F70ED2 200deg, #6804FD 330deg);
 
         @media only screen and (max-width: 750px) {
-            width: min(90%, 325px);
-            background: none;
-            top: 10%;
+            width: max(320px, 50%);
+            margin-top: 10%;
         }
     }
 
@@ -30,7 +26,6 @@
     }
 
     .sign-up-subscription-form {
-        position: absolute;
         z-index: 800;
         width: 100%;
         height: 100%;

--- a/src/pages/landingPages/signUp/CallToAction/ThankYou/ThankYou.js
+++ b/src/pages/landingPages/signUp/CallToAction/ThankYou/ThankYou.js
@@ -1,0 +1,9 @@
+export default function ThankYou({text}) {
+    return (
+        <>
+            <span className="cta-heading">Thank You!</span>
+            <br />
+            <span className="cta-subheading"> {text === "a" ? "You have now subscribed to our email newsletter. You should receive a confirmation email soon. Ad Astra!🚀" : "You are now a part of the SpaceLab community! We appreciate your subscription to our newsletter and look forward to sharing the latest updates on space exploration and our projects.  Ad Astra!🚀"}</span>
+        </>
+     )
+}


### PR DESCRIPTION
- Separated text for A/B testing into components and passing a prop into the component to dictate which version is displayed. Default will be the "a" version (shorter text).
- Adjusted styling and responsive design so elements won't shift with text changes.

![Screenshot 2023-06-08 at 5 44 32 PM](https://github.com/spacelabdev/spacelab-react/assets/119830622/20c3ed3f-0cd6-4135-a1bc-c6beb9cfbec1)
![Screenshot 2023-06-08 at 5 44 54 PM](https://github.com/spacelabdev/spacelab-react/assets/119830622/83e3652b-ba4c-4afe-88e8-40c0899a8b5d)
![Screenshot 2023-06-08 at 5 45 26 PM](https://github.com/spacelabdev/spacelab-react/assets/119830622/aa4583f0-f40b-4add-901d-0a8de6c82c4c)
![Screenshot 2023-06-08 at 5 45 50 PM](https://github.com/spacelabdev/spacelab-react/assets/119830622/d23b3467-b66d-4e48-9e51-3cd8654cf1d7)
