### PR TITLE
Glossary Page Search Bar Functionality PR.

### DIFF
--- a/src/components/dynamicSearchBar/SearchBar.js
+++ b/src/components/dynamicSearchBar/SearchBar.js
@@ -43,7 +43,7 @@ function SearchBar({ data, HandleSearchTermClick, clearData }) {
 						? value.title.toLowerCase()
 						: null;
 					const levenshteinDistance = getLevenshteinDistance(
-						searchTerm,
+						searchTerm.toLowerCase(),
 						target
 					);
 					const fuzzyChars = 0;


### PR DESCRIPTION
Fixes: #367

Hello again, Spacelab team.

I tried a solution for the issue mentioned  above: in order to fix this issue I converted the searchTerm to lower case in order to match lower cased target constant, this way since both terms are lower cased, regardless of their initial state search terms will now match whether they are searched for in upper or lower case.

This how search results look for the term "stellar" in upper case:

![image](https://github.com/spacelabdev/spacelab-react/assets/4129325/bf767c31-463b-4076-951c-d29a5a6b01ac)

And in lower case:

![image](https://github.com/spacelabdev/spacelab-react/assets/4129325/d2fa49dc-3c38-4ca2-874d-1ca8b1ce8f62)


Also for "planet", in upper case:

![image](https://github.com/spacelabdev/spacelab-react/assets/4129325/8209cc62-d6ca-4369-a9c2-35673fa96cd7)

And in lower case:

![image](https://github.com/spacelabdev/spacelab-react/assets/4129325/c2e2ce5f-2bb8-4dca-a1fd-067b03f522e4)



