### PR TITLE
Enhancement/385 make resources dropdown keyboard accessible

### DIFF
--- a/src/components/navigation/MainNavigation/MainNavigation.jsx
+++ b/src/components/navigation/MainNavigation/MainNavigation.jsx
@@ -31,61 +31,78 @@ export default function MainNavigation() {
 							<img src={Logo} alt="logo" />
 						</Link>
 					</div>
-					<div className="nav-links">
-						<Link
-							className={"nav-link"}
-							to={"/about"}
-							style={{ textDecoration: "none" }}
-						>
-							About
-						</Link>
-						<div to={"#"} className={"nav-dropdown nav-link"}>
-							Resources
-							<div className={"dropdown-content"}>
-								<Link
-									className={"nav-link"}
-									to={"/projects"}
-									style={{ textDecoration: "none" }}
-								>
-									Projects
-								</Link>
-								<Link
-									className={"nav-link"}
-									to={"/discovery"}
-									style={{ textDecoration: "none" }}
-								>
-									Discovery
-								</Link>
-								<Link
-									className={"nav-link"}
-									to={"/glossary"}
-									style={{ textDecoration: "none" }}
-								>
-									Glossary
-								</Link>
-								<Link
-									className={"nav-link"}
-									to={"/podcast"}
-									style={{ textDecoration: "none" }}
-								>
-									Podcast
-								</Link>
-							</div>
-						</div>
-						<Link
-							className={"nav-link"}
-							to={"/blog"}
-							style={{ textDecoration: "none" }}
-						>
-							Blog
-						</Link>
-						<Link 
-							className={'nav-link'} 
-							to={'/donate'} 
-							style={{textDecoration: 'none'}}
-						>
-							Donate
-						</Link>
+					<ul className="nav-links">
+						<li>
+							<Link
+								className={"nav-link"}
+								to={"/about"}
+								style={{ textDecoration: "none" }}
+							>
+								About
+							</Link>
+						</li>
+						{/* <div to={"#"} className={"nav-dropdown nav-link"}> */}
+						<li className={"nav-dropdown nav-link"}>
+							<a href="#" className={"dropdown-nav-name"}>Resources</a>
+							<ul className={"dropdown-content"}>
+								<li>
+									<Link
+										className={"nav-link"}
+										to={"/projects"}
+										style={{ textDecoration: "none" }}
+									>
+										Projects
+									</Link>
+								</li>
+								<li>
+									<Link
+										className={"nav-link"}
+										to={"/discovery"}
+										style={{ textDecoration: "none" }}
+									>
+										Discovery
+									</Link>
+								</li>
+								<li>
+									<Link
+										className={"nav-link"}
+										to={"/glossary"}
+										style={{ textDecoration: "none" }}
+									>
+										Glossary
+									</Link>
+								</li>
+								<li>
+									<Link
+										className={"nav-link"}
+										to={"/podcast"}
+										style={{ textDecoration: "none" }}
+									>
+										Podcast
+									</Link>
+								</li>
+							</ul>
+						</li>
+						{/* </div> */}
+
+						<li>
+							<Link
+								className={"nav-link"}
+								to={"/blog"}
+								style={{ textDecoration: "none" }}
+							>
+								Blog
+							</Link>
+						</li>
+						<li>
+							<Link 
+								className={'nav-link'} 
+								to={'/donate'} 
+								style={{textDecoration: 'none'}}
+							>
+								Donate
+							</Link>
+						</li>
 						{/* <a
 							className="nav-link"
 							href="https://www.paypal.com/donate/?hosted_button_id=PK9D4A3HEWV8C"
@@ -94,14 +111,16 @@ export default function MainNavigation() {
 						>
 							Donate
 						</a> */}
-						<Link
-							className={"nav-link"}
-							to={"/contact"}
-							style={{ textDecoration: "none" }}
-						>
-							Contact
-						</Link>
-					</div>
+						<li>
+							<Link
+								className={"nav-link"}
+								to={"/contact"}
+								style={{ textDecoration: "none" }}
+							>
+								Contact
+							</Link>
+						</li>
+					</ul>
 				</div>
 			</nav>
 		</>

--- a/src/components/navigation/MainNavigation/mainNavigation.scss
+++ b/src/components/navigation/MainNavigation/mainNavigation.scss
@@ -101,9 +101,13 @@ nav {
 				}
 
 				.dropdown-nav-name {
-					font-size: 1.25rem;
-					color: #ffffff;
+					// font-size: 1.25rem;
+					// color: #ffffff;
 					margin: 0;
+
+					&:hover{
+						text-decoration: none;
+					}
 				}
 
 				.dropdown-content {

--- a/src/components/navigation/MainNavigation/mainNavigation.scss
+++ b/src/components/navigation/MainNavigation/mainNavigation.scss
@@ -81,6 +81,7 @@ nav {
 
 		.nav-links {
 			display: none;
+			list-style-type: none;
 			@media (min-width: 1024px) {
 				display: flex;
 				font-size: 1.5em;
@@ -106,6 +107,7 @@ nav {
 				}
 
 				.dropdown-content {
+				    list-style-type: none;
 					display: none;
 					position: absolute;
 					z-index: 1;
@@ -115,7 +117,8 @@ nav {
 				}
 			}
 
-			.nav-dropdown:hover .dropdown-content {
+			.nav-dropdown:hover .dropdown-content,
+			.nav-dropdown:focus-within .dropdown-content {
 				display: block;
 			}
 

--- a/src/components/navigation/MainNavigation/mainNavigation.scss
+++ b/src/components/navigation/MainNavigation/mainNavigation.scss
@@ -109,6 +109,10 @@ nav {
 					&:hover{
 						text-decoration: none;
 					}
+
+					&:focus{
+						outline-offset: 15px;
+					}
 				}
 
 				.dropdown-content {

--- a/src/components/navigation/MainNavigation/mainNavigation.scss
+++ b/src/components/navigation/MainNavigation/mainNavigation.scss
@@ -82,6 +82,7 @@ nav {
 		.nav-links {
 			display: none;
 			list-style-type: none;
+			margin: 0;
 			@media (min-width: 1024px) {
 				display: flex;
 				font-size: 1.5em;


### PR DESCRIPTION
- Made resources dropdown keyboard accessible (using tab & shift + tab to navigate) using the :focus-within pseudo class -- but in order for this to work, I had to convert the entire nav menu to a ul element and its children to li elements.
- Made some styling changes to adjust new changes above to current style
- Added an offset (padding) to the focus outline for the resources element so that it matches the focus outline of the other nav links

Resources: 
- https://www.a11ywithlindsey.com/blog/create-accessible-dropdown-navigation
- https://www.a11ywithlindsey.com/blog/create-accessible-dropdown-navigation-without-js