### PR TITLE
Enhancement/blogcarousel

### DIFF
--- a/src/components/carouselComponents/BlogCarousel/blogCarousel.scss
+++ b/src/components/carouselComponents/BlogCarousel/blogCarousel.scss
@@ -46,7 +46,7 @@
 	}
 
 	.blog-carousel-image-wrapper:focus-within {
-		border: 1px solid white;
+		border: 2px solid white;
 	}
 
 	.d-block {

--- a/src/components/carouselComponents/BlogCarousel/blogCarousel.scss
+++ b/src/components/carouselComponents/BlogCarousel/blogCarousel.scss
@@ -89,15 +89,20 @@
 .carousel-control-prev {
 	height: 500px;
 	@media (max-width: 767px) {
-		height: 200px;
+		height: 500px;
 	}
 	@media (min-width: 767px) and (max-width: 1023px) {
+		border: 1px solid black;
 		display: none;
 	}
 
 	.sr-only {
 		display: none;
 	}
+}
+
+.carousel-control-prev:focus-within {
+	border: 1px solid white;
 }
 
 .carousel-control-next {
@@ -112,6 +117,10 @@
 	.sr-only {
 		display: none;
 	}
+}
+
+.carousel-control-next:focus-within {
+	border: 1px solid white;
 }
 
 .archives-button-container {

--- a/src/components/carouselComponents/BlogCarousel/blogCarousel.scss
+++ b/src/components/carouselComponents/BlogCarousel/blogCarousel.scss
@@ -44,6 +44,10 @@
 			object-fit: cover;
 		}
 	}
+	
+	.blog-carousel-image-wrapper:focus-within {
+		border: 1px solid white;
+	}
 
 	.d-block {
 		width: 100%;

--- a/src/components/carouselComponents/BlogCarousel/blogCarousel.scss
+++ b/src/components/carouselComponents/BlogCarousel/blogCarousel.scss
@@ -44,7 +44,7 @@
 			object-fit: cover;
 		}
 	}
-	
+
 	.blog-carousel-image-wrapper:focus-within {
 		border: 1px solid white;
 	}
@@ -92,12 +92,15 @@
 
 .carousel-control-prev {
 	height: 500px;
+	width: 100px;
 	@media (max-width: 767px) {
-		height: 500px;
+		height: 200px;
+		width: 50px;
 	}
 	@media (min-width: 767px) and (max-width: 1023px) {
 		border: 1px solid black;
 		display: none;
+		
 	}
 
 	.sr-only {
@@ -111,8 +114,10 @@
 
 .carousel-control-next {
 	height: 500px;
+	width: 100px;
 	@media (max-width: 767px) {
 		height: 200px;
+		width: 50px;
 	}
 	@media (min-width: 767px) and (max-width: 1023px) {
 		display: none;


### PR DESCRIPTION
Added visibility to selecting arrows for Blog Carousel for keyboard users.
Added the ability for the rotating blogs to be selected using keyboard controls using :focus-within, allowing the user to open the link of the currently shown blog.

![Screenshot (353)](https://github.com/spacelabdev/spacelab-react/assets/12283471/3c65a0f1-6e46-4591-a599-e007156bcc01)
![Screenshot (354)](https://github.com/spacelabdev/spacelab-react/assets/12283471/a3082638-0f2a-4710-a376-8a7f6e5fb239)
