### PR TITLE
Enhancement #387: Added aria-labels to each social media link and hid icons from screen reader

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -95,8 +95,9 @@ export default function Footer() {
 							target="_blank"
 							rel="noreferrer"
 							title="Follow us on LinkedIn"
+							aria-label="Follow us on LinkedIn"
 						>
-							<FaLinkedin />
+							<FaLinkedin aria-hidden="true"/>
 						</a>
 
 						<a
@@ -104,8 +105,9 @@ export default function Footer() {
 							target="_blank"
 							rel="noreferrer"
 							title="Read Spacelab articles on Medium"
+							aria-label="Read Spacelab articles on Medium"
 						>
-							<BsMedium />
+							<BsMedium aria-hidden="true"/>
 						</a>
 
 						<a
@@ -113,16 +115,18 @@ export default function Footer() {
 							target="_blank"
 							rel="noreferrer"
 							title="Follow us on Instagram"
+							aria-label="Follow us on Instagram"
 						>
-							<AiOutlineInstagram />
+							<AiOutlineInstagram aria-hidden="true"/>
 						</a>
 						<a
 							href="https://twitter.com/SpaceLab_social"
 							target="_blank"
 							rel="noreferrer"
 							title="Follow us on Twitter"
+							aria-label="Follow us on Twitter"
 						>
-							<AiOutlineTwitter />
+							<AiOutlineTwitter aria-hidden="true"/>
 						</a>
 					</IconContext.Provider>
 					<p>@2023 by SpaceLab</p>


### PR DESCRIPTION
Issue: the current "title" attributes in the social media <a> elements are not read by screen readers. In this case, the title attribute may fall into the exception mentioned in the following article and may be read to screen readers, but I think best practice is to avoid using title attributes for accessibility.

reference article: https://silktide.com/blog/i-thought-title-text-improved-accessibility-i-was-wrong/#:~:text=The%20only%20very%20tiny%20exception,title%20attribute%2C%20don't.

Title attributes are great for when you hover over an icon and want to see more info about that icon though!

To resolve this, I:

1. Added aria labels to each social media link:
I basically took Anna's first suggestion of adding descriptive text to each icon, but instead of using an alt tag, which is not supported for <a> elements, I used the "aria-label" attribute. This basically adds a label to the <a> tag, which the screen reader will read aloud.

2. Hid Icons from screen reader
I set the "aria-hidden" attribute to "true" for each icon so that the screen reader skips it. The entire <a> element itself will be announced to the screen reader, and since each icon is already enclosed in an <a> element, there is no need to announce the icon inside as it will serve no purpose to the screen reader.

code reference: https://savvas.me/accessibility/problem-with-social-icons