### PR TITLE
Commented out podcast link on Footer and HamburgerMenu

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -70,11 +70,14 @@ export default function Footer() {
 										Projects
 									</Link>
 								</li>
+								{/* // Removed this link until podcast page becomes active. */}
+								{/*}
 								<li>
 									<Link to={"/podcast"} style={link_style}>
 										Podcast
 									</Link>
 								</li>
+								*/}
 							</ul>
 						</div>
 						

--- a/src/components/navigation/HamburgerMenu/HamburgerMenu.jsx
+++ b/src/components/navigation/HamburgerMenu/HamburgerMenu.jsx
@@ -5,7 +5,7 @@ import "./hamburgerMenu.scss";
 import { useState } from "react";
 
 /**
- * Renders the hamburger menu for smaller scree sizes.
+ * Renders the hamburger menu for smaller screen sizes.
  *
  *  More information on react-burger-menu can be found here:
  *  https://github.com/negomi/react-burger-menu
@@ -51,13 +51,14 @@ function HamburgerMenu() {
 							>
 								Glossary
 							</Link>
-							<Link
+							{/* // Removed this link until podcast page becomes active. */}
+							{/* <Link
 								className={"hamburger-nav-link"}
 								to={"/podcast"}
 								style={{ textDecoration: "none" }}
 							>
 								Podcast
-							</Link>
+							</Link> */}
 							{/* // Removed until blog page on Medium is back up. */}
 							{/* <Link
 								className={"hamburger-nav-link"}

--- a/src/components/navigation/MainNavigation/MainNavigation.jsx
+++ b/src/components/navigation/MainNavigation/MainNavigation.jsx
@@ -93,6 +93,8 @@ export default function MainNavigation() {
 										Glossary
 									</Link>
 								</li>
+								{/*
+								// Removed this link until podcast page becomes active.
 								<li>
 									<Link
 										className={"nav-link"}
@@ -102,6 +104,7 @@ export default function MainNavigation() {
 										Podcast
 									</Link>
 								</li>
+								*/}
 							</ul>
 						</li>
 						{/* </div> */}


### PR DESCRIPTION
Commented out links to/mentions of podcast page on the navbar and footer files. See paths to the two files below. Added comment above commented out sections: Removed this link until podcast page becomes active.
- navbar. Path: src/components/navigation/HamburgerMenu
- footer. Path: src/components/navigation/Footer